### PR TITLE
Day10: fixed-price offers + one-pager

### DIFF
--- a/docs/offers/offer-ci-48h.md
+++ b/docs/offers/offer-ci-48h.md
@@ -1,0 +1,18 @@
+# Fixed-price: Turn Your Foundry Repo Green (CI) in 48h
+
+**Scope**
+- Configure GitHub Actions to run `forge test -vvv` in `evm/`
+- Publish gas report artifacts
+- Add status badge in README
+- Provide a 1-page handover doc
+
+**Deliverables**
+- Working CI workflow
+- Gas artifact(s) in Actions
+- PR with README badge
+
+**Proof**
+- See Day4/Day5 evidence packs in this repo.
+
+**Price & Timeline**
+- $X, delivered in ~48 hours (one iteration included)

--- a/docs/offers/offer-erc20-taxed.md
+++ b/docs/offers/offer-erc20-taxed.md
@@ -1,0 +1,17 @@
+# Fixed-price: ERC20 with Tax/Whitelist/Blacklist/Pause (OZ v5)
+
+**Scope**
+- Taxed ERC20 based on `_update` hook (OpenZeppelin v5)
+- Whitelist & blacklist; pause/unpause
+- Unit tests + gas report + Slither check
+
+**Deliverables**
+- Source code + tests
+- Evidence pack (gas, CI, slither)
+- Optional deployment script
+
+**Proof**
+- See Day6 evidence pack.
+
+**Price & Timeline**
+- $Y, delivered in ~3–5 days (two iterations included)

--- a/docs/offers/offer-etherscan-verify.md
+++ b/docs/offers/offer-etherscan-verify.md
@@ -1,0 +1,17 @@
+# Fixed-price: Etherscan Verification & Step-by-Step Docs
+
+**Scope**
+- Verify existing contracts on Etherscan/BaseScan
+- Write reproducible verification steps and scripts
+- (Optional) integrate with Foundry `forge verify-contract`
+
+**Deliverables**
+- Verified contract links
+- Step-by-step docs
+- Evidence pack with links & tx hashes
+
+**Proof**
+- See Day7 evidence pack.
+
+**Price & Timeline**
+- $Z, delivered in ~48–72 hours

--- a/docs/offers/offer-vesting-frontend.md
+++ b/docs/offers/offer-vesting-frontend.md
@@ -1,0 +1,17 @@
+# Fixed-price: Vesting Vault + Minimal Frontend
+
+**Scope**
+- Linear vesting with cliff (VestingVault)
+- Minimal Next.js + wagmi UI: connect + 1 action button
+- Tests + scripts + evidence
+
+**Deliverables**
+- Contract + tests + UI
+- Deployed demo (optional)
+- Evidence (screenshots/links)
+
+**Proof**
+- See Day8 evidence additions.
+
+**Price & Timeline**
+- $W, delivered in ~5–7 days

--- a/docs/sales/onepager.md
+++ b/docs/sales/onepager.md
@@ -1,0 +1,25 @@
+# Smart Contract Delivery — One-Pager
+
+## Problem
+- Teams need reproducible, verifiable Web3 deliverables (tests/CI/evidence)
+- Onchain demo & verification are often missing in MVPs
+
+## Solution
+- Launchkit: ERC20 factory, taxed token, fee router, vesting, CI, evidence packs
+- Proven integration on Sepolia with verifiable links
+
+## Evidence
+- Day5–Day9 packs: tests, gas, Etherscan links, Slither reports
+
+## Process
+1) Kickoff & scope confirmation (1h)
+2) Dev & tests (daily progress)
+3) Onchain verify (if included)
+4) Handover & doc
+
+## Timeline & Pricing
+- CI in 48h; ERC20 + features in 3–5 days; vesting + UI in 5–7 days
+- Fixed price per offer
+
+## Contact
+- GitHub: https://github.com/lzh840723/launchkit


### PR DESCRIPTION
Adds offers (CI 48h, ERC20 taxed, Etherscan verify, Vesting+UI) and sales one-pager.